### PR TITLE
Add RPM field and storeRpm calculation to exercise endpoints

### DIFF
--- a/internal/handlers/exercise_handler.go
+++ b/internal/handlers/exercise_handler.go
@@ -56,16 +56,23 @@ func (h *ExerciseHandler) ListExercisesByName(w http.ResponseWriter, r *http.Req
 	utils.WriteJSONResponse(w, exercise, http.StatusOK)
 }
 
+type exerciseRequest struct {
+	models.Exercise
+	StoreRPM bool `json:"storeRpm"`
+}
+
 func (h *ExerciseHandler) CreateExercise(w http.ResponseWriter, r *http.Request) {
-	var exercise models.Exercise
 	vars := mux.Vars(r)
 	userId := vars["userId"]
-	if err := utils.DecodeJSON(r.Body, &exercise); err != nil {
+
+	var req exerciseRequest
+	if err := utils.DecodeJSON(r.Body, &req); err != nil {
 		utils.WriteErrorResponse(w, err)
 		return
 	}
 
-	if err := h.service.CreateExercise(userId, &exercise); err != nil {
+	exercise := req.Exercise
+	if err := h.service.CreateExercise(userId, &exercise, req.StoreRPM); err != nil {
 		utils.WriteErrorResponse(w, err)
 		return
 	}
@@ -78,13 +85,14 @@ func (h *ExerciseHandler) UpdateExercise(w http.ResponseWriter, r *http.Request)
 	userID := vars["userId"]
 	exerciseID := vars["exerciseId"]
 
-	var exercise models.Exercise
-	if err := utils.DecodeJSON(r.Body, &exercise); err != nil {
+	var req exerciseRequest
+	if err := utils.DecodeJSON(r.Body, &req); err != nil {
 		utils.WriteErrorResponse(w, err)
 		return
 	}
 
-	if err := h.service.UpdateExercise(userID, exerciseID, &exercise); err != nil {
+	exercise := req.Exercise
+	if err := h.service.UpdateExercise(userID, exerciseID, &exercise, req.StoreRPM); err != nil {
 		utils.WriteErrorResponse(w, err)
 		return
 	}

--- a/internal/models/exercise.go
+++ b/internal/models/exercise.go
@@ -37,6 +37,7 @@ type Exercise struct {
 	Level        float64      `json:"level,omitempty"`
 	Reps         int          `json:"reps,omitempty"`
 	Sets         []WeightItem `json:"sets,omitempty"`
+	RPM          float64      `json:"rpm,omitempty"`
 }
 
 func (e *Exercise) Validate() error {

--- a/internal/services/exercise_service.go
+++ b/internal/services/exercise_service.go
@@ -3,13 +3,14 @@ package services
 import (
 	"gym-tracker-api/internal/models"
 	"gym-tracker-api/internal/repository"
+	"strings"
 )
 
 type ExerciseService interface {
 	GetExercise(userID, exerciseID string) (*models.Exercise, error)
 	GetExercises(userID string) ([]*models.Exercise, error)
-	CreateExercise(userID string, exercise *models.Exercise) error
-	UpdateExercise(userID, exerciseID string, exercise *models.Exercise) error
+	CreateExercise(userID string, exercise *models.Exercise, storeRpm bool) error
+	UpdateExercise(userID, exerciseID string, exercise *models.Exercise, storeRpm bool) error
 	DeleteExercise(userID, exerciseID string) error
 	ListExercisesByType(userID, exerciseType string) ([]*models.Exercise, error)
 	ListExercisesByName(userID, exerciseName string) ([]*models.Exercise, error)
@@ -41,19 +42,51 @@ func (s *exerciseService) GetExercises(userID string) ([]*models.Exercise, error
 	return exercises, nil
 }
 
-func (s *exerciseService) CreateExercise(userID string, exercise *models.Exercise) error {
+func (s *exerciseService) CreateExercise(userID string, exercise *models.Exercise, storeRpm bool) error {
 	if err := exercise.Validate(); err != nil {
 		return err
+	}
+	if storeRpm {
+		exercise.RPM = calculateRPM(exercise)
 	}
 	return s.repo.Create(userID, exercise)
 }
 
-func (s *exerciseService) UpdateExercise(userID string, exerciseID string, exercise *models.Exercise) error {
+func (s *exerciseService) UpdateExercise(userID string, exerciseID string, exercise *models.Exercise, storeRpm bool) error {
 	if err := exercise.Validate(); err != nil {
 		return err
 	}
 	exercise.ExerciseID = exerciseID
+	if storeRpm {
+		exercise.RPM = calculateRPM(exercise)
+	}
 	return s.repo.Update(userID, exercise)
+}
+
+// calculateRPM computes revolutions per minute for a cardio exercise.
+// Requires cardio type, a positive time (seconds), and distance in miles or km.
+// Uses the rule: 6.2 metres = 1 revolution.
+func calculateRPM(exercise *models.Exercise) float64 {
+	if exercise.ExerciseType != models.ExerciseTypeCardio {
+		return 0
+	}
+	if exercise.Time <= 0 || exercise.Distance <= 0 {
+		return 0
+	}
+
+	var distanceMeters float64
+	switch strings.ToLower(exercise.DistanceUnit) {
+	case "miles", "mile":
+		distanceMeters = exercise.Distance * 1609.344
+	case "km", "kilometers", "kilometre", "kilometres":
+		distanceMeters = exercise.Distance * 1000
+	default:
+		return 0
+	}
+
+	revolutions := distanceMeters / 6.2
+	minutes := float64(exercise.Time) / 60.0
+	return revolutions / minutes
 }
 
 func (s *exerciseService) DeleteExercise(userID, exerciseID string) error {

--- a/internal/services/exercise_service_test.go
+++ b/internal/services/exercise_service_test.go
@@ -2,10 +2,15 @@ package services
 
 import (
 	"errors"
+	"math"
 	"testing"
 
 	"gym-tracker-api/internal/models"
 )
+
+func approxEqual(a, b float64) bool {
+	return math.Abs(a-b) < 1e-9
+}
 
 // mockExerciseRepo implements repository.ExerciseRepository for testing.
 type mockExerciseRepo struct {
@@ -103,7 +108,7 @@ func TestGetExercises_RepoError(t *testing.T) {
 func TestCreateExercise_Success(t *testing.T) {
 	svc := NewExerciseService(&mockExerciseRepo{})
 
-	if err := svc.CreateExercise("user-1", sampleExercise()); err != nil {
+	if err := svc.CreateExercise("user-1", sampleExercise(), false); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -114,7 +119,7 @@ func TestCreateExercise_MissingName(t *testing.T) {
 	e := sampleExercise()
 	e.Name = ""
 
-	if err := svc.CreateExercise("user-1", e); err == nil {
+	if err := svc.CreateExercise("user-1", e, false); err == nil {
 		t.Error("expected validation error for missing name, got nil")
 	}
 }
@@ -125,7 +130,7 @@ func TestCreateExercise_MissingExerciseType(t *testing.T) {
 	e := sampleExercise()
 	e.ExerciseType = ""
 
-	if err := svc.CreateExercise("user-1", e); err == nil {
+	if err := svc.CreateExercise("user-1", e, false); err == nil {
 		t.Error("expected validation error for missing exerciseType, got nil")
 	}
 }
@@ -136,7 +141,7 @@ func TestCreateExercise_MissingID(t *testing.T) {
 	e := sampleExercise()
 	e.ExerciseID = ""
 
-	if err := svc.CreateExercise("user-1", e); err == nil {
+	if err := svc.CreateExercise("user-1", e, false); err == nil {
 		t.Error("expected validation error for missing exerciseId, got nil")
 	}
 }
@@ -144,7 +149,7 @@ func TestCreateExercise_MissingID(t *testing.T) {
 func TestCreateExercise_RepoError(t *testing.T) {
 	svc := NewExerciseService(&mockExerciseRepo{err: errors.New("write failed")})
 
-	if err := svc.CreateExercise("user-1", sampleExercise()); err == nil {
+	if err := svc.CreateExercise("user-1", sampleExercise(), false); err == nil {
 		t.Error("expected repo error, got nil")
 	}
 }
@@ -154,7 +159,7 @@ func TestCreateExercise_RepoError(t *testing.T) {
 func TestUpdateExercise_Success(t *testing.T) {
 	svc := NewExerciseService(&mockExerciseRepo{})
 
-	if err := svc.UpdateExercise("user-1", "ex-1", sampleExercise()); err != nil {
+	if err := svc.UpdateExercise("user-1", "ex-1", sampleExercise(), false); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -165,8 +170,115 @@ func TestUpdateExercise_ValidationError(t *testing.T) {
 	e := sampleExercise()
 	e.Name = ""
 
-	if err := svc.UpdateExercise("user-1", "ex-1", e); err == nil {
+	if err := svc.UpdateExercise("user-1", "ex-1", e, false); err == nil {
 		t.Error("expected validation error, got nil")
+	}
+}
+
+// calculateRPM
+
+func sampleCardioExercise() *models.Exercise {
+	return &models.Exercise{
+		ExerciseID:   "ex-2",
+		Name:         "Cycling",
+		ExerciseType: "cardio",
+		Distance:     10,
+		DistanceUnit: "km",
+		Time:         3600, // 60 minutes
+	}
+}
+
+func TestCalculateRPM_KM(t *testing.T) {
+	// 10 km = 10000 m; revolutions = 10000 / 6.2 ≈ 1612.9; minutes = 3600/60 = 60; rpm ≈ 26.88
+	e := sampleCardioExercise()
+	rpm := calculateRPM(e)
+	expected := (10000.0 / 6.2) / 60.0
+	if !approxEqual(rpm, expected) {
+		t.Errorf("expected rpm %f, got %f", expected, rpm)
+	}
+}
+
+func TestCalculateRPM_Miles(t *testing.T) {
+	// 5 miles = 5 * 1609.344 = 8046.72 m; revolutions = 8046.72 / 6.2 ≈ 1297.86; minutes = 1800/60 = 30; rpm ≈ 43.26
+	e := &models.Exercise{
+		ExerciseID:   "ex-3",
+		Name:         "Running",
+		ExerciseType: "cardio",
+		Distance:     5,
+		DistanceUnit: "miles",
+		Time:         1800,
+	}
+	rpm := calculateRPM(e)
+	expected := (5 * 1609.344 / 6.2) / 30.0
+	if !approxEqual(rpm, expected) {
+		t.Errorf("expected rpm %f, got %f", expected, rpm)
+	}
+}
+
+func TestCalculateRPM_NonCardio(t *testing.T) {
+	e := sampleExercise() // weights exercise
+	if rpm := calculateRPM(e); rpm != 0 {
+		t.Errorf("expected 0 for non-cardio, got %f", rpm)
+	}
+}
+
+func TestCalculateRPM_MissingTime(t *testing.T) {
+	e := sampleCardioExercise()
+	e.Time = 0
+	if rpm := calculateRPM(e); rpm != 0 {
+		t.Errorf("expected 0 when time is missing, got %f", rpm)
+	}
+}
+
+func TestCalculateRPM_MissingDistance(t *testing.T) {
+	e := sampleCardioExercise()
+	e.Distance = 0
+	if rpm := calculateRPM(e); rpm != 0 {
+		t.Errorf("expected 0 when distance is missing, got %f", rpm)
+	}
+}
+
+func TestCalculateRPM_UnsupportedUnit(t *testing.T) {
+	e := sampleCardioExercise()
+	e.DistanceUnit = "meters"
+	if rpm := calculateRPM(e); rpm != 0 {
+		t.Errorf("expected 0 for unsupported distance unit, got %f", rpm)
+	}
+}
+
+func TestCreateExercise_StoreRPM(t *testing.T) {
+	svc := NewExerciseService(&mockExerciseRepo{})
+
+	e := sampleCardioExercise()
+	if err := svc.CreateExercise("user-1", e, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if e.RPM == 0 {
+		t.Error("expected RPM to be populated when storeRpm is true")
+	}
+}
+
+func TestCreateExercise_StoreRPM_False(t *testing.T) {
+	svc := NewExerciseService(&mockExerciseRepo{})
+
+	e := sampleCardioExercise()
+	if err := svc.CreateExercise("user-1", e, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if e.RPM != 0 {
+		t.Error("expected RPM to be 0 when storeRpm is false")
+	}
+}
+
+func TestUpdateExercise_StoreRPM(t *testing.T) {
+	svc := NewExerciseService(&mockExerciseRepo{})
+
+	e := sampleCardioExercise()
+	if err := svc.UpdateExercise("user-1", "ex-2", e, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if e.RPM == 0 {
+		t.Error("expected RPM to be populated when storeRpm is true")
 	}
 }
 


### PR DESCRIPTION
Adds an optional `rpm` field to the Exercise model. The POST and PUT
exercise endpoints now accept a `storeRpm` boolean (default false). When
true and the exercise is cardio with time and a miles/km distance, RPM is
calculated using the rule 6.2 m = 1 revolution and stored on the exercise.

https://claude.ai/code/session_01BkxwdUGipUQcwXENSEsAZC